### PR TITLE
Fix memory Leak

### DIFF
--- a/lib/schedule.js
+++ b/lib/schedule.js
@@ -100,7 +100,7 @@ function Job(name, job, callback) {
     // remove from scheduledJobs if reschedule === false
     if (!reschedule) {
       if (this.name) {
-        scheduledJobs[this.name] = null;
+        delete scheduledJobs[this.name];
       }
     }
 


### PR DESCRIPTION
When a schedule is canceled without reschedule, its instant is removed from the list but the name of the instance was remaining.

After some added and canceled jobs, the list was full of null values.